### PR TITLE
Changes necessary to make broker work with Edge

### DIFF
--- a/src/session_broker.rs
+++ b/src/session_broker.rs
@@ -193,9 +193,13 @@ where
     c.request_name("com.microsoft.identity.broker1", false, true, false)?;
 
     let mut cr = crossroads::Crossroads::new();
-    let token = register_session_broker::<T>(&mut cr);
 
-    cr.insert("/com/microsoft/identity/broker1", &[token], broker);
+    let token = register_session_broker::<T>(&mut cr);
+    let peer = cr.register("org.freedesktop.DBus.Peer", |b| {
+        b.method("Ping", (), (),
+            |_, _, (): ()| Ok(()));
+    });
+    cr.insert("/com/microsoft/identity/broker1", &[token, peer], broker);
 
     // Serve clients forever.
     cr.serve(&c)?;


### PR DESCRIPTION
Edge expects the dbus service to implement the `org.freedesktop.DBus.Peer.Ping` method. This patch adds that method because crossroads does not do so.

Looking at https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces, crossroads does implement the other three standard interfaces (ObjectManager, Introspectable, Properties, https://docs.rs/dbus-crossroads/latest/dbus_crossroads/struct.Crossroads.html#method.set_add_standard_ifaces). So I wonder if we maybe should raise this with upstream instead?