### PR TITLE
Implement LogControl1 interface and add more debug logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "identity_dbus_broker"
 description = "DBus Broker which supplies credentials for authenticated Entra ID users"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 authors = [
     "David Mulder <dmulder@suse.com>"

--- a/src/broker_proto.rs
+++ b/src/broker_proto.rs
@@ -17,6 +17,7 @@
 */
 
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 #[allow(non_camel_case_types)]
 #[derive(Serialize, Deserialize)]
@@ -29,4 +30,38 @@ pub enum ClientRequest {
     generateSignedHttpRequest(String, String, String),
     cancelInteractiveFlow(String, String, String),
     getLinuxBrokerVersion(String, String, String),
+}
+
+impl ClientRequest {
+    pub fn method_name(&self) -> &'static str {
+        match self {
+            ClientRequest::acquireTokenInteractively(..) => "acquireTokenInteractively",
+            ClientRequest::acquireTokenSilently(..) => "acquireTokenSilently",
+            ClientRequest::getAccounts(..) => "getAccounts",
+            ClientRequest::removeAccount(..) => "removeAccount",
+            ClientRequest::acquirePrtSsoCookie(..) => "acquirePrtSsoCookie",
+            ClientRequest::generateSignedHttpRequest(..) => "generateSignedHttpRequest",
+            ClientRequest::cancelInteractiveFlow(..) => "cancelInteractiveFlow",
+            ClientRequest::getLinuxBrokerVersion(..) => "getLinuxBrokerVersion",
+        }
+    }
+
+    pub fn correlation_id(&self) -> &str {
+        match self {
+            ClientRequest::acquireTokenInteractively(_, cid, _)
+            | ClientRequest::acquireTokenSilently(_, cid, _)
+            | ClientRequest::getAccounts(_, cid, _)
+            | ClientRequest::removeAccount(_, cid, _)
+            | ClientRequest::acquirePrtSsoCookie(_, cid, _)
+            | ClientRequest::generateSignedHttpRequest(_, cid, _)
+            | ClientRequest::cancelInteractiveFlow(_, cid, _)
+            | ClientRequest::getLinuxBrokerVersion(_, cid, _) => cid,
+        }
+    }
+}
+
+impl fmt::Display for ClientRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}(correlation_id={})", self.method_name(), self.correlation_id())
+    }
 }

--- a/src/himmelblau_broker.rs
+++ b/src/himmelblau_broker.rs
@@ -140,6 +140,7 @@ where
     let mut reqs = Framed::new(sock, ClientCodec);
 
     while let Some(Ok(req)) = reqs.next().await {
+        debug!("Daemon received request from uid {}: {}", uid, req);
         let resp = match req {
             ClientRequest::acquireTokenInteractively(
                 protocol_version,
@@ -254,9 +255,10 @@ where
                     .await?
             }
         };
+        debug!("Daemon sending response ({} bytes) to uid {}", resp.len(), uid);
         reqs.send(resp).await?;
         reqs.flush().await?;
-        debug!("flushed response!");
+        debug!("Daemon flushed response to uid {}", uid);
     }
 
     debug!("Disconnecting client ...");

--- a/src/session_broker.rs
+++ b/src/session_broker.rs
@@ -23,6 +23,7 @@ use dbus_crossroads as crossroads;
 use std::error::Error;
 use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
+use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
 use tracing::{debug, error};
@@ -184,7 +185,60 @@ where
     })
 }
 
-pub async fn session_broker_serve<T>(broker: T) -> Result<(), dbus::MethodErr>
+/// Callbacks for getting and setting the log level at runtime.
+/// Used by the LogControl1 D-Bus interface to bridge into whatever
+/// logging framework the caller uses (e.g. tracing-subscriber reload).
+pub struct LogLevelCallbacks {
+    pub get: Arc<dyn Fn() -> String + Send + Sync>,
+    pub set: Arc<dyn Fn(&str) -> Result<(), String> + Send + Sync>,
+}
+
+struct LogControlState {
+    syslog_identifier: String,
+    callbacks: LogLevelCallbacks,
+}
+
+fn register_log_control1(
+    cr: &mut crossroads::Crossroads,
+) -> crossroads::IfaceToken<LogControlState> {
+    cr.register("org.freedesktop.LogControl1", |b| {
+        b.property::<String, _>("LogLevel")
+            .emits_changed_false()
+            .get(|_ctx, data: &mut LogControlState| {
+                Ok((data.callbacks.get)())
+            })
+            .set(
+                |_ctx, data: &mut LogControlState, value: String| {
+                    (data.callbacks.set)(&value).map_err(|e| {
+                        dbus::MethodErr::failed(&e)
+                    })?;
+                    Ok(None)
+                },
+            );
+        b.property::<String, _>("LogTarget")
+            .emits_changed_false()
+            .get(|_ctx, _data: &mut LogControlState| {
+                Ok("journal".to_string())
+            })
+            .set(
+                |_ctx, _data: &mut LogControlState, _value: String| {
+                    Err(("org.freedesktop.DBus.Error.NotSupported",
+                        "Setting log target is not supported".to_string()).into())
+                },
+            );
+        b.property::<String, _>("SyslogIdentifier")
+            .emits_changed_false()
+            .get(|_ctx, data: &mut LogControlState| {
+                Ok(data.syslog_identifier.clone())
+            });
+    })
+}
+
+pub async fn session_broker_serve<T>(
+    broker: T,
+    syslog_identifier: &str,
+    log_callbacks: LogLevelCallbacks,
+) -> Result<(), dbus::MethodErr>
 where
     T: SessionBroker + Send + 'static,
 {
@@ -200,6 +254,16 @@ where
             |_, _, (): ()| Ok(()));
     });
     cr.insert("/com/microsoft/identity/broker1", &[token, peer], broker);
+
+    let log_control_token = register_log_control1(&mut cr);
+    cr.insert(
+        "/org/freedesktop/LogControl1",
+        &[log_control_token],
+        LogControlState {
+            syslog_identifier: syslog_identifier.to_string(),
+            callbacks: log_callbacks,
+        },
+    );
 
     // Serve clients forever.
     cr.serve(&c)?;
@@ -414,10 +478,15 @@ impl SessionBroker for HimmelblauSessionBroker {
 pub async fn himmelblau_session_broker_serve(
     sock_path: &str,
     timeout: u64,
+    log_callbacks: LogLevelCallbacks,
 ) -> Result<(), dbus::MethodErr> {
-    session_broker_serve(HimmelblauSessionBroker {
-        sock_path: sock_path.to_string(),
-        timeout,
-    })
+    session_broker_serve(
+        HimmelblauSessionBroker {
+            sock_path: sock_path.to_string(),
+            timeout,
+        },
+        "himmelblau_broker",
+        log_callbacks,
+    )
     .await
 }

--- a/src/session_broker.rs
+++ b/src/session_broker.rs
@@ -90,96 +90,120 @@ where
             "acquireTokenInteractively",
             ("protocol_version", "correlation_id", "request_json"),
             ("result",),
-            |_, t: &mut T, (protocol_version, correlation_id, request_json)| {
-                t.acquire_token_interactively(
+            |_, t: &mut T, (protocol_version, correlation_id, request_json): (String, String, String)| {
+                debug!("D-Bus call: acquireTokenInteractively, correlation_id={}", correlation_id);
+                let result = t.acquire_token_interactively(
                     protocol_version,
-                    correlation_id,
+                    correlation_id.clone(),
                     request_json,
-                )
-                .map(|x| (x,))
+                );
+                debug!("D-Bus reply: acquireTokenInteractively, correlation_id={}, success={}",
+                    correlation_id, result.is_ok());
+                result.map(|x| (x,))
             },
         );
         b.method(
             "acquireTokenSilently",
             ("protocol_version", "correlation_id", "request_json"),
             ("result",),
-            |_, t: &mut T, (protocol_version, correlation_id, request_json)| {
-                t.acquire_token_silently(
+            |_, t: &mut T, (protocol_version, correlation_id, request_json): (String, String, String)| {
+                debug!("D-Bus call: acquireTokenSilently, correlation_id={}", correlation_id);
+                let result = t.acquire_token_silently(
                     protocol_version,
-                    correlation_id,
+                    correlation_id.clone(),
                     request_json,
-                )
-                .map(|x| (x,))
+                );
+                debug!("D-Bus reply: acquireTokenSilently, correlation_id={}, success={}",
+                    correlation_id, result.is_ok());
+                result.map(|x| (x,))
             },
         );
         b.method(
             "getAccounts",
             ("protocol_version", "correlation_id", "request_json"),
             ("result",),
-            |_, t: &mut T, (protocol_version, correlation_id, request_json)| {
-                t.get_accounts(protocol_version, correlation_id, request_json)
-                    .map(|x| (x,))
+            |_, t: &mut T, (protocol_version, correlation_id, request_json): (String, String, String)| {
+                debug!("D-Bus call: getAccounts, correlation_id={}", correlation_id);
+                let result = t.get_accounts(protocol_version, correlation_id.clone(), request_json);
+                debug!("D-Bus reply: getAccounts, correlation_id={}, success={}",
+                    correlation_id, result.is_ok());
+                result.map(|x| (x,))
             },
         );
         b.method(
             "removeAccount",
             ("protocol_version", "correlation_id", "request_json"),
             ("result",),
-            |_, t: &mut T, (protocol_version, correlation_id, request_json)| {
-                t.remove_account(protocol_version, correlation_id, request_json)
-                    .map(|x| (x,))
+            |_, t: &mut T, (protocol_version, correlation_id, request_json): (String, String, String)| {
+                debug!("D-Bus call: removeAccount, correlation_id={}", correlation_id);
+                let result = t.remove_account(protocol_version, correlation_id.clone(), request_json);
+                debug!("D-Bus reply: removeAccount, correlation_id={}, success={}",
+                    correlation_id, result.is_ok());
+                result.map(|x| (x,))
             },
         );
         b.method(
             "acquirePrtSsoCookie",
             ("protocol_version", "correlation_id", "request_json"),
             ("result",),
-            |_, t: &mut T, (protocol_version, correlation_id, request_json)| {
-                t.acquire_prt_sso_cookie(
+            |_, t: &mut T, (protocol_version, correlation_id, request_json): (String, String, String)| {
+                debug!("D-Bus call: acquirePrtSsoCookie, correlation_id={}", correlation_id);
+                let result = t.acquire_prt_sso_cookie(
                     protocol_version,
-                    correlation_id,
+                    correlation_id.clone(),
                     request_json,
-                )
-                .map(|x| (x,))
+                );
+                debug!("D-Bus reply: acquirePrtSsoCookie, correlation_id={}, success={}",
+                    correlation_id, result.is_ok());
+                result.map(|x| (x,))
             },
         );
         b.method(
             "generateSignedHttpRequest",
             ("protocol_version", "correlation_id", "request_json"),
             ("result",),
-            |_, t: &mut T, (protocol_version, correlation_id, request_json)| {
-                t.generate_signed_http_request(
+            |_, t: &mut T, (protocol_version, correlation_id, request_json): (String, String, String)| {
+                debug!("D-Bus call: generateSignedHttpRequest, correlation_id={}", correlation_id);
+                let result = t.generate_signed_http_request(
                     protocol_version,
-                    correlation_id,
+                    correlation_id.clone(),
                     request_json,
-                )
-                .map(|x| (x,))
+                );
+                debug!("D-Bus reply: generateSignedHttpRequest, correlation_id={}, success={}",
+                    correlation_id, result.is_ok());
+                result.map(|x| (x,))
             },
         );
         b.method(
             "cancelInteractiveFlow",
             ("protocol_version", "correlation_id", "request_json"),
             ("result",),
-            |_, t: &mut T, (protocol_version, correlation_id, request_json)| {
-                t.cancel_interactive_flow(
+            |_, t: &mut T, (protocol_version, correlation_id, request_json): (String, String, String)| {
+                debug!("D-Bus call: cancelInteractiveFlow, correlation_id={}", correlation_id);
+                let result = t.cancel_interactive_flow(
                     protocol_version,
-                    correlation_id,
+                    correlation_id.clone(),
                     request_json,
-                )
-                .map(|x| (x,))
+                );
+                debug!("D-Bus reply: cancelInteractiveFlow, correlation_id={}, success={}",
+                    correlation_id, result.is_ok());
+                result.map(|x| (x,))
             },
         );
         b.method(
             "getLinuxBrokerVersion",
             ("protocol_version", "correlation_id", "request_json"),
             ("result",),
-            |_, t: &mut T, (protocol_version, correlation_id, request_json)| {
-                t.get_linux_broker_version(
+            |_, t: &mut T, (protocol_version, correlation_id, request_json): (String, String, String)| {
+                debug!("D-Bus call: getLinuxBrokerVersion, correlation_id={}", correlation_id);
+                let result = t.get_linux_broker_version(
                     protocol_version,
-                    correlation_id,
+                    correlation_id.clone(),
                     request_json,
-                )
-                .map(|x| (x,))
+                );
+                debug!("D-Bus reply: getLinuxBrokerVersion, correlation_id={}, success={}",
+                    correlation_id, result.is_ok());
+                result.map(|x| (x,))
             },
         );
     })
@@ -280,6 +304,10 @@ impl HimmelblauSessionBroker {
         &self,
         message: ClientRequest,
     ) -> Result<String, Box<dyn Error>> {
+        debug!(
+            "Connecting to daemon socket {} for request {}",
+            self.sock_path, message
+        );
         let mut stream = UnixStream::connect(&self.sock_path)
             .map_err(|e| {
                 error!(
@@ -289,15 +317,23 @@ impl HimmelblauSessionBroker {
                 e
             })
             .map_err(Box::new)?;
+        debug!("Connected to daemon socket for {}", message);
 
+        let serialized = serde_json::to_vec(&message)?;
+        debug!(
+            "Sending {} bytes to daemon for {}",
+            serialized.len(),
+            message
+        );
         stream
-            .write_all(&serde_json::to_vec(&message)?)
+            .write_all(&serialized)
             .and_then(|_| stream.flush())
             .map_err(|e| {
-                error!("stream write error -> {:?}", e);
+                error!("stream write error for {} -> {:?}", message, e);
                 e
             })
             .map_err(Box::new)?;
+        debug!("Request sent to daemon for {}, waiting for response", message);
 
         // Now wait on the response.
         let start = SystemTime::now();
@@ -311,16 +347,19 @@ impl HimmelblauSessionBroker {
             let durr =
                 SystemTime::now().duration_since(start).map_err(Box::new)?;
             if durr > timeout {
-                error!("Socket timeout");
+                error!(
+                    "Socket timeout after {:?} waiting for daemon response to {}",
+                    durr, message
+                );
                 break;
             }
             match stream.read(&mut buffer) {
                 Ok(0) => {
                     if read_started {
-                        debug!("read_started true, we have completed");
+                        debug!("read_started true, we have completed for {}", message);
                         break;
                     } else {
-                        debug!("Waiting ...");
+                        debug!("Waiting for daemon response to {} ...", message);
                         continue;
                     }
                 }
@@ -328,22 +367,26 @@ impl HimmelblauSessionBroker {
                     data.extend_from_slice(&buffer);
                     counter += count;
                     if count == 1024 {
-                        debug!("Filled 1024 bytes, looping ...");
+                        debug!("Filled 1024 bytes for {}, looping ...", message);
                         read_started = true;
                         continue;
                     } else {
-                        debug!("Filled {} bytes, complete", count);
+                        debug!("Filled {} bytes for {}, complete", count, message);
                         break;
                     }
                 }
                 Err(e) => {
-                    error!("Stream read failure from {:?} -> {:?}", &stream, e);
+                    error!("Stream read failure for {} from {:?} -> {:?}", message, &stream, e);
                     return Err(Box::new(e));
                 }
             }
         }
 
         data.truncate(counter);
+        debug!(
+            "Received {} bytes from daemon for {}",
+            counter, message
+        );
 
         Ok(String::from_utf8(data)?)
     }


### PR DESCRIPTION
LogControl1 is a D-Bus interface defined to provide a standardized set of APIs to control the logging output of a D-Bus service.

Utilities like systemctl have integrated controls that allow changing these settings in a standard and common way, e.g.:

systemctl service-log-level foo.service debug

https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.LogControl1.html

Implement it with callbacks to actually set/get the settings, so that the service implementers can adapt it to their needs.