### PR TITLE
Improve error handling for D-Bus calls

### DIFF
--- a/src/himmelblau_broker.rs
+++ b/src/himmelblau_broker.rs
@@ -141,6 +141,11 @@ where
 
     while let Some(Ok(req)) = reqs.next().await {
         debug!("Daemon received request from uid {}: {}", uid, req);
+        let is_token_request = matches!(
+            req,
+            ClientRequest::acquireTokenInteractively(..)
+                | ClientRequest::acquireTokenSilently(..)
+        );
         let resp = match match req {
             ClientRequest::acquireTokenInteractively(
                 protocol_version,
@@ -258,7 +263,24 @@ where
             Ok(r) => r,
             Err(e) => {
                 error!("Broker method failed for uid {}: {}", uid, e);
-                serde_json::json!({"error": e.to_string()}).to_string()
+                let error_obj = serde_json::json!({
+                    "context": e.to_string(),
+                    "status": 0,
+                    "subStatus": 0
+                });
+                if is_token_request {
+                    serde_json::json!({
+                        "brokerTokenResponse": {
+                            "error": error_obj
+                        }
+                    })
+                    .to_string()
+                } else {
+                    serde_json::json!({
+                        "error": error_obj
+                    })
+                    .to_string()
+                }
             }
         };
         debug!("Daemon sending response ({} bytes) to uid {}", resp.len(), uid);

--- a/src/himmelblau_broker.rs
+++ b/src/himmelblau_broker.rs
@@ -141,7 +141,7 @@ where
 
     while let Some(Ok(req)) = reqs.next().await {
         debug!("Daemon received request from uid {}: {}", uid, req);
-        let resp = match req {
+        let resp = match match req {
             ClientRequest::acquireTokenInteractively(
                 protocol_version,
                 correlation_id,
@@ -154,7 +154,7 @@ where
                         request_json,
                         uid,
                     )
-                    .await?
+                    .await
             }
             ClientRequest::acquireTokenSilently(
                 protocol_version,
@@ -168,7 +168,7 @@ where
                         request_json,
                         uid,
                     )
-                    .await?
+                    .await
             }
             ClientRequest::getAccounts(
                 protocol_version,
@@ -182,7 +182,7 @@ where
                         request_json,
                         uid,
                     )
-                    .await?
+                    .await
             }
             ClientRequest::removeAccount(
                 protocol_version,
@@ -196,7 +196,7 @@ where
                         request_json,
                         uid,
                     )
-                    .await?
+                    .await
             }
             ClientRequest::acquirePrtSsoCookie(
                 protocol_version,
@@ -210,7 +210,7 @@ where
                         request_json,
                         uid,
                     )
-                    .await?
+                    .await
             }
             ClientRequest::generateSignedHttpRequest(
                 protocol_version,
@@ -224,7 +224,7 @@ where
                         request_json,
                         uid,
                     )
-                    .await?
+                    .await
             }
             ClientRequest::cancelInteractiveFlow(
                 protocol_version,
@@ -238,7 +238,7 @@ where
                         request_json,
                         uid,
                     )
-                    .await?
+                    .await
             }
             ClientRequest::getLinuxBrokerVersion(
                 protocol_version,
@@ -252,7 +252,13 @@ where
                         request_json,
                         uid,
                     )
-                    .await?
+                    .await
+            }
+        } {
+            Ok(r) => r,
+            Err(e) => {
+                error!("Broker method failed for uid {}: {}", uid, e);
+                serde_json::json!({"error": e.to_string()}).to_string()
             }
         };
         debug!("Daemon sending response ({} bytes) to uid {}", resp.len(), uid);


### PR DESCRIPTION
Follow the reference implementation in how it returns errors to callers over D-Bus, so that applications have an easier time handling them regardless of the implementation in use