### PR TITLE
Add interactive auth protocol for multi-step credential prompting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ serde_json = "1.0.128"
 tokio = { version = "1.40.0", features = ["rt", "sync", "macros"] }
 tokio-util = { version = "0.7.12", features = ["codec"] }
 tracing = "0.1.40"
+
+[features]
+interactive = []

--- a/src/broker_proto.rs
+++ b/src/broker_proto.rs
@@ -19,6 +19,79 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Response from the daemon during an interactive authentication flow.
+#[cfg(feature = "interactive")]
+#[derive(Serialize, Deserialize)]
+pub enum InteractiveAuthResponse {
+    /// Prompt the user for their password.
+    PromptPassword,
+    /// Prompt the user for their Hello PIN.
+    PromptPin,
+    /// Prompt the user for an MFA verification code.
+    PromptMFACode { msg: String },
+    /// The user must approve an MFA request on another device; poll.
+    PromptMFAPoll { msg: String, polling_interval: u32 },
+    /// Prompt the user for FIDO2 authentication.
+    PromptFido {
+        fido_challenge: String,
+        fido_allow_list: Vec<String>,
+    },
+    /// Authentication succeeded; contains the broker token response JSON.
+    Success { token_response: String },
+    /// Authentication was denied.
+    Denied { msg: String },
+}
+
+#[cfg(feature = "interactive")]
+impl std::fmt::Debug for InteractiveAuthResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PromptPassword => f.write_str("PromptPassword"),
+            Self::PromptPin => f.write_str("PromptPin"),
+            Self::PromptMFACode { msg } => {
+                f.debug_struct("PromptMFACode").field("msg", msg).finish()
+            }
+            Self::PromptMFAPoll { msg, polling_interval } => {
+                f.debug_struct("PromptMFAPoll")
+                    .field("msg", msg)
+                    .field("polling_interval", polling_interval)
+                    .finish()
+            }
+            Self::PromptFido { .. } => f.write_str("PromptFido { .. }"),
+            Self::Success { .. } => f.write_str("Success { token_response: [REDACTED] }"),
+            Self::Denied { msg } => {
+                f.debug_struct("Denied").field("msg", msg).finish()
+            }
+        }
+    }
+}
+
+/// Credential submitted by the session broker during an interactive step.
+#[cfg(feature = "interactive")]
+#[derive(Serialize, Deserialize)]
+pub enum InteractiveAuthCredential {
+    Password { cred: String },
+    Pin { cred: String },
+    MFACode { cred: String },
+    MFAPoll { poll_attempt: u32 },
+    Fido { assertion: String },
+}
+
+#[cfg(feature = "interactive")]
+impl std::fmt::Debug for InteractiveAuthCredential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Password { .. } => f.write_str("Password { cred: [REDACTED] }"),
+            Self::Pin { .. } => f.write_str("Pin { cred: [REDACTED] }"),
+            Self::MFACode { .. } => f.write_str("MFACode { cred: [REDACTED] }"),
+            Self::MFAPoll { poll_attempt } => {
+                f.debug_struct("MFAPoll").field("poll_attempt", poll_attempt).finish()
+            }
+            Self::Fido { .. } => f.write_str("Fido { assertion: [REDACTED] }"),
+        }
+    }
+}
+
 #[allow(non_camel_case_types)]
 #[derive(Serialize, Deserialize)]
 pub enum ClientRequest {
@@ -30,6 +103,15 @@ pub enum ClientRequest {
     generateSignedHttpRequest(String, String, String),
     cancelInteractiveFlow(String, String, String),
     getLinuxBrokerVersion(String, String, String),
+    /// Start an interactive auth session (protocol_version, correlation_id, request_json).
+    #[cfg(feature = "interactive")]
+    interactiveAuthInit(String, String, String),
+    /// Submit a credential for an in-flight interactive session (correlation_id, credential_json).
+    #[cfg(feature = "interactive")]
+    interactiveAuthStep(String, String),
+    /// Cancel an in-flight interactive session (correlation_id).
+    #[cfg(feature = "interactive")]
+    interactiveAuthCancel(String),
 }
 
 impl ClientRequest {
@@ -43,6 +125,12 @@ impl ClientRequest {
             ClientRequest::generateSignedHttpRequest(..) => "generateSignedHttpRequest",
             ClientRequest::cancelInteractiveFlow(..) => "cancelInteractiveFlow",
             ClientRequest::getLinuxBrokerVersion(..) => "getLinuxBrokerVersion",
+            #[cfg(feature = "interactive")]
+            ClientRequest::interactiveAuthInit(..) => "interactiveAuthInit",
+            #[cfg(feature = "interactive")]
+            ClientRequest::interactiveAuthStep(..) => "interactiveAuthStep",
+            #[cfg(feature = "interactive")]
+            ClientRequest::interactiveAuthCancel(..) => "interactiveAuthCancel",
         }
     }
 
@@ -56,6 +144,12 @@ impl ClientRequest {
             | ClientRequest::generateSignedHttpRequest(_, cid, _)
             | ClientRequest::cancelInteractiveFlow(_, cid, _)
             | ClientRequest::getLinuxBrokerVersion(_, cid, _) => cid,
+            #[cfg(feature = "interactive")]
+            ClientRequest::interactiveAuthInit(_, cid, _) => cid,
+            #[cfg(feature = "interactive")]
+            ClientRequest::interactiveAuthStep(cid, _) => cid,
+            #[cfg(feature = "interactive")]
+            ClientRequest::interactiveAuthCancel(cid) => cid,
         }
     }
 }

--- a/src/himmelblau_broker.rs
+++ b/src/himmelblau_broker.rs
@@ -86,6 +86,35 @@ pub trait HimmelblauBroker {
         request_json: String,
         uid: uid_t,
     ) -> Result<String, Box<dyn Error>>;
+
+    /// Begin an interactive authentication session for the caller.
+    /// Returns a JSON-serialized `InteractiveAuthResponse`.
+    #[cfg(feature = "interactive")]
+    async fn interactive_auth_init(
+        &mut self,
+        protocol_version: String,
+        correlation_id: String,
+        request_json: String,
+        uid: uid_t,
+    ) -> Result<String, Box<dyn Error>>;
+
+    /// Submit a credential for an in-flight interactive session.
+    /// Returns a JSON-serialized `InteractiveAuthResponse`.
+    #[cfg(feature = "interactive")]
+    async fn interactive_auth_step(
+        &mut self,
+        correlation_id: String,
+        credential_json: String,
+        uid: uid_t,
+    ) -> Result<String, Box<dyn Error>>;
+
+    /// Cancel an in-flight interactive session.
+    #[cfg(feature = "interactive")]
+    async fn interactive_auth_cancel(
+        &mut self,
+        correlation_id: String,
+        uid: uid_t,
+    ) -> Result<String, Box<dyn Error>>;
 }
 
 #[derive(Default)]
@@ -255,6 +284,45 @@ where
                         protocol_version,
                         correlation_id,
                         request_json,
+                        uid,
+                    )
+                    .await
+            }
+            #[cfg(feature = "interactive")]
+            ClientRequest::interactiveAuthInit(
+                protocol_version,
+                correlation_id,
+                request_json,
+            ) => {
+                broker
+                    .interactive_auth_init(
+                        protocol_version,
+                        correlation_id,
+                        request_json,
+                        uid,
+                    )
+                    .await
+            }
+            #[cfg(feature = "interactive")]
+            ClientRequest::interactiveAuthStep(
+                correlation_id,
+                credential_json,
+            ) => {
+                broker
+                    .interactive_auth_step(
+                        correlation_id,
+                        credential_json,
+                        uid,
+                    )
+                    .await
+            }
+            #[cfg(feature = "interactive")]
+            ClientRequest::interactiveAuthCancel(
+                correlation_id,
+            ) => {
+                broker
+                    .interactive_auth_cancel(
+                        correlation_id,
                         uid,
                     )
                     .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,5 @@ pub use session_broker::*;
 mod device_broker;
 pub use device_broker::*;
 mod broker_proto;
+#[cfg(feature = "interactive")]
+pub use broker_proto::{InteractiveAuthCredential, InteractiveAuthResponse};

--- a/src/session_broker.rs
+++ b/src/session_broker.rs
@@ -25,8 +25,31 @@ use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::SystemTime;
 use tracing::{debug, error};
+
+#[cfg(feature = "interactive")]
+use crate::broker_proto::{InteractiveAuthCredential, InteractiveAuthResponse};
+
+/// Trait for handling interactive authentication prompts.
+///
+/// Implementors can customize how each kind of prompt is presented to the
+/// user (e.g. using `pinentry` for secrets and the `authenticator` crate
+/// for FIDO2).
+#[cfg(feature = "interactive")]
+pub trait InteractivePromptHandler: Send + Sync {
+    /// Prompt the user for a secret (password, PIN, MFA code).
+    /// Returns `None` if the user cancels.
+    fn prompt_secret(&self, description: &str, prompt: &str) -> Option<String>;
+    /// Display an informational message to the user (non-blocking).
+    fn show_message(&self, _message: &str) {}
+    /// Perform a FIDO2 assertion and return the JSON-encoded result.
+    /// Returns `None` if the user cancels or the operation fails.
+    fn fido_auth(
+        &self,
+        fido_challenge: &str,
+        fido_allow_list: &[String],
+    ) -> Option<String>;
+}
 
 pub trait SessionBroker {
     fn acquire_token_interactively(
@@ -294,9 +317,82 @@ where
     unreachable!()
 }
 
+/// Read a complete JSON response from the stream by attempting
+/// deserialization after each chunk. This avoids requiring a
+/// framing protocol and works with the raw-JSON wire format.
+fn recv_json_response(
+    stream: &mut UnixStream,
+    timeout: Duration,
+    request_name: &dyn std::fmt::Display,
+) -> Result<String, Box<dyn Error>> {
+    const MAX_RESPONSE_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
+    stream.set_read_timeout(Some(timeout))?;
+
+    let mut data = Vec::with_capacity(4096);
+    let mut buf = [0u8; 4096];
+
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                data.extend_from_slice(&buf[..n]);
+                if data.len() > MAX_RESPONSE_SIZE {
+                    return Err(format!(
+                        "Response for {} exceeded max size ({} bytes)",
+                        request_name, MAX_RESPONSE_SIZE
+                    ).into());
+                }
+                // Try to parse, a complete JSON value means we're done.
+                if serde_json::from_slice::<serde_json::Value>(&data).is_ok() {
+                    break;
+                }
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock
+                || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                // If we already have data, try to parse what we have.
+                if !data.is_empty()
+                    && serde_json::from_slice::<serde_json::Value>(&data).is_ok()
+                {
+                    break;
+                }
+                error!(
+                    "Socket timeout waiting for daemon response to {}",
+                    request_name
+                );
+                return Err(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("Timeout waiting for response to {}", request_name),
+                )));
+            }
+            Err(e) => {
+                error!("Stream read failure for {} -> {:?}", request_name, e);
+                return Err(Box::new(e));
+            }
+        }
+    }
+
+    // Verify we got a complete JSON value before returning.
+    if data.is_empty() || serde_json::from_slice::<serde_json::Value>(&data).is_err() {
+        error!(
+            "Unexpected EOF after {} bytes for {}, no valid JSON response",
+            data.len(), request_name
+        );
+        return Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            format!("Unexpected EOF waiting for response to {}", request_name),
+        )));
+    }
+
+    debug!("Received {} bytes from daemon for {}", data.len(), request_name);
+    Ok(String::from_utf8(data)?)
+}
+
 struct HimmelblauSessionBroker {
     sock_path: String,
     timeout: u64,
+    #[cfg(feature = "interactive")]
+    prompt_handler: Arc<dyn InteractivePromptHandler>,
 }
 
 impl HimmelblauSessionBroker {
@@ -335,60 +431,182 @@ impl HimmelblauSessionBroker {
             .map_err(Box::new)?;
         debug!("Request sent to daemon for {}, waiting for response", message);
 
-        // Now wait on the response.
-        let start = SystemTime::now();
-        let mut read_started = false;
-        let mut data = Vec::with_capacity(1024);
-        let mut counter = 0;
         let timeout = Duration::from_secs(self.timeout);
+        recv_json_response(&mut stream, timeout, &message)
+    }
 
-        loop {
-            let mut buffer = [0; 1024];
-            let durr =
-                SystemTime::now().duration_since(start).map_err(Box::new)?;
-            if durr > timeout {
-                error!(
-                    "Socket timeout after {:?} waiting for daemon response to {}",
-                    durr, message
-                );
-                break;
-            }
-            match stream.read(&mut buffer) {
-                Ok(0) => {
-                    if read_started {
-                        debug!("read_started true, we have completed for {}", message);
-                        break;
-                    } else {
-                        debug!("Waiting for daemon response to {} ...", message);
-                        continue;
-                    }
-                }
-                Ok(count) => {
-                    data.extend_from_slice(&buffer);
-                    counter += count;
-                    if count == 1024 {
-                        debug!("Filled 1024 bytes for {}, looping ...", message);
-                        read_started = true;
-                        continue;
-                    } else {
-                        debug!("Filled {} bytes for {}, complete", count, message);
-                        break;
-                    }
-                }
-                Err(e) => {
-                    error!("Stream read failure for {} from {:?} -> {:?}", message, &stream, e);
-                    return Err(Box::new(e));
-                }
-            }
-        }
-
-        data.truncate(counter);
+    /// Send a request on an already-open stream and read the response.
+    #[cfg(feature = "interactive")]
+    fn send_and_recv(
+        &self,
+        stream: &mut UnixStream,
+        message: ClientRequest,
+    ) -> Result<String, Box<dyn Error>> {
+        let serialized = serde_json::to_vec(&message)?;
         debug!(
-            "Received {} bytes from daemon for {}",
-            counter, message
+            "Sending {} bytes to daemon for {}",
+            serialized.len(),
+            message
+        );
+        stream
+            .write_all(&serialized)
+            .and_then(|_| stream.flush())
+            .map_err(|e| {
+                error!("stream write error for {} -> {:?}", message, e);
+                e
+            })
+            .map_err(Box::new)?;
+
+        let timeout = Duration::from_secs(self.timeout);
+        recv_json_response(stream, timeout, &message)
+    }
+
+    /// Drive the interactive authentication flow over a single connection.
+    ///
+    /// 1. Sends `interactiveAuthInit` to the daemon.
+    /// 2. Reads intermediate prompts and collects credentials via `pinentry`.
+    /// 3. Sends `interactiveAuthStep` until the daemon returns success or denied.
+    #[cfg(feature = "interactive")]
+    fn request_interactive(
+        &self,
+        protocol_version: String,
+        correlation_id: String,
+        request_json: String,
+    ) -> Result<String, Box<dyn Error>> {
+        debug!(
+            "Starting interactive auth flow, correlation_id={}",
+            correlation_id
         );
 
-        Ok(String::from_utf8(data)?)
+        let mut stream = UnixStream::connect(&self.sock_path).map_err(|e| {
+            error!(
+                "Interactive: socket connect error to {} -> {:?}",
+                self.sock_path, e
+            );
+            Box::new(e)
+        })?;
+
+        // Step 1: Send init
+        let init_resp = self.send_and_recv(
+            &mut stream,
+            ClientRequest::interactiveAuthInit(
+                protocol_version,
+                correlation_id.clone(),
+                request_json,
+            ),
+        )?;
+
+        let mut resp: InteractiveAuthResponse = serde_json::from_str(&init_resp)?;
+
+        // Step 2: Loop prompting until success or denial
+        let max_steps = 10;
+        for step in 0..max_steps {
+            let response_kind = match &resp {
+                InteractiveAuthResponse::Success { .. } => "Success",
+                InteractiveAuthResponse::Denied { .. } => "Denied",
+                InteractiveAuthResponse::PromptPassword => "PromptPassword",
+                InteractiveAuthResponse::PromptPin => "PromptPin",
+                InteractiveAuthResponse::PromptMFACode { .. } => "PromptMFACode",
+                InteractiveAuthResponse::PromptMFAPoll { .. } => "PromptMFAPoll",
+                InteractiveAuthResponse::PromptFido { .. } => "PromptFido",
+            };
+            debug!(
+                "Interactive auth step {}, correlation_id={}, response={}",
+                step, correlation_id, response_kind
+            );
+            let cred = match &resp {
+                InteractiveAuthResponse::Success { token_response } => {
+                    return Ok(token_response.clone());
+                }
+                InteractiveAuthResponse::Denied { msg } => {
+                    return Err(msg.clone().into());
+                }
+                InteractiveAuthResponse::PromptPassword => {
+                    match self.prompt_handler.prompt_secret(
+                        "Entra ID Authentication",
+                        "Password:",
+                    ) {
+                        Some(cred) => InteractiveAuthCredential::Password { cred },
+                        None => {
+                            let _ = self.send_and_recv(
+                                &mut stream,
+                                ClientRequest::interactiveAuthCancel(correlation_id.clone()),
+                            );
+                            return Err("User cancelled authentication".into());
+                        }
+                    }
+                }
+                InteractiveAuthResponse::PromptPin => {
+                    match self.prompt_handler.prompt_secret(
+                        "Entra ID Authentication",
+                        "Hello PIN:",
+                    ) {
+                        Some(cred) => InteractiveAuthCredential::Pin { cred },
+                        None => {
+                            let _ = self.send_and_recv(
+                                &mut stream,
+                                ClientRequest::interactiveAuthCancel(correlation_id.clone()),
+                            );
+                            return Err("User cancelled authentication".into());
+                        }
+                    }
+                }
+                InteractiveAuthResponse::PromptMFACode { msg } => {
+                    match self.prompt_handler.prompt_secret("Entra ID MFA", msg) {
+                        Some(cred) => InteractiveAuthCredential::MFACode { cred },
+                        None => {
+                            let _ = self.send_and_recv(
+                                &mut stream,
+                                ClientRequest::interactiveAuthCancel(correlation_id.clone()),
+                            );
+                            return Err("User cancelled authentication".into());
+                        }
+                    }
+                }
+                InteractiveAuthResponse::PromptMFAPoll {
+                    msg, polling_interval,
+                } => {
+                    if !msg.is_empty() {
+                        self.prompt_handler.show_message(msg);
+                    }
+                    std::thread::sleep(Duration::from_secs(*polling_interval as u64));
+                    InteractiveAuthCredential::MFAPoll {
+                        poll_attempt: step as u32,
+                    }
+                }
+                InteractiveAuthResponse::PromptFido {
+                    fido_challenge,
+                    fido_allow_list,
+                } => {
+                    match self
+                        .prompt_handler
+                        .fido_auth(fido_challenge, fido_allow_list)
+                    {
+                        Some(assertion) => InteractiveAuthCredential::Fido { assertion },
+                        None => {
+                            let _ = self.send_and_recv(
+                                &mut stream,
+                                ClientRequest::interactiveAuthCancel(correlation_id.clone()),
+                            );
+                            return Err("FIDO2 authentication failed or cancelled".into());
+                        }
+                    }
+                }
+            };
+
+            let cred_json = serde_json::to_string(&cred)?;
+            let step_resp = self.send_and_recv(
+                &mut stream,
+                ClientRequest::interactiveAuthStep(correlation_id.clone(), cred_json),
+            )?;
+            resp = serde_json::from_str(&step_resp)?;
+        }
+
+        let _ = self.send_and_recv(
+            &mut stream,
+            ClientRequest::interactiveAuthCancel(correlation_id),
+        );
+        Err("Interactive auth: too many steps".into())
     }
 }
 
@@ -399,12 +617,43 @@ impl SessionBroker for HimmelblauSessionBroker {
         correlation_id: String,
         request_json: String,
     ) -> Result<String, dbus::MethodErr> {
-        self.request(ClientRequest::acquireTokenInteractively(
-            protocol_version,
-            correlation_id,
-            request_json,
-        ))
-        .map_err(|e| dbus::MethodErr::failed(&e))
+        // First try the existing daemon-side path (one-shot request).
+        let initial_result = self.request(ClientRequest::acquireTokenInteractively(
+            protocol_version.clone(),
+            correlation_id.clone(),
+            request_json.clone(),
+        ));
+
+        match &initial_result {
+            Ok(resp) => {
+                // Check if the response contains a valid token
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(resp) {
+                    if v.get("brokerTokenResponse")
+                        .and_then(|t| t.get("accessToken"))
+                        .is_some()
+                    {
+                        return initial_result.map_err(|e| dbus::MethodErr::failed(&e));
+                    }
+                }
+            }
+            Err(_) => {}
+        }
+
+        #[cfg(feature = "interactive")]
+        {
+            debug!(
+                "One-shot acquisition did not return a token for correlation_id={}, starting interactive flow",
+                correlation_id
+            );
+            return self
+                .request_interactive(protocol_version, correlation_id, request_json)
+                .map_err(|e| dbus::MethodErr::failed(&e));
+        }
+
+        #[cfg(not(feature = "interactive"))]
+        {
+            initial_result.map_err(|e| dbus::MethodErr::failed(&e))
+        }
     }
 
     fn acquire_token_silently(
@@ -522,11 +771,15 @@ pub async fn himmelblau_session_broker_serve(
     sock_path: &str,
     timeout: u64,
     log_callbacks: LogLevelCallbacks,
+    #[cfg(feature = "interactive")]
+    prompt_handler: Arc<dyn InteractivePromptHandler>,
 ) -> Result<(), dbus::MethodErr> {
     session_broker_serve(
         HimmelblauSessionBroker {
             sock_path: sock_path.to_string(),
             timeout,
+            #[cfg(feature = "interactive")]
+            prompt_handler,
         },
         "himmelblau_broker",
         log_callbacks,


### PR DESCRIPTION
Add feature-gated ("interactive") support for interactive authentication flows between the session broker and daemon:

- InteractiveAuthResponse/InteractiveAuthCredential protocol types supporting password, PIN, MFA code, MFA poll, and FIDO2
- InteractivePromptHandler trait for pluggable prompt UIs
- Three new HimmelblauBroker trait methods: interactive_auth_init, interactive_auth_step, interactive_auth_cancel
- Session broker drives the multi-step loop, falling back from silent to interactive when acquireTokenInteractively fails silently

All new code is behind cfg(feature = "interactive") to avoid breaking compat.

This will be used in himmelblau to implement acquireTokenInteractively via the broker and pinentry.